### PR TITLE
fix(GraphQL): Request a GraphQL setting variables

### DIFF
--- a/packages/security/src/template/rest.template.ts
+++ b/packages/security/src/template/rest.template.ts
@@ -67,7 +67,8 @@ export class RestTemplate {
 
     return this.httpService
       .post(url, {
-        query
+        query,
+        variables,
       }, {
         headers: {
           Authorization: `Bearer ${token}`,


### PR DESCRIPTION
![gif_or_image](https://media.giphy.com/media/2YnstawziiaeY05bcj/giphy.gif)

### What?
variables support

### Why?
cause, this will be use on queries and mutations.

**Example**:
```shell
curl --request POST --url 'https://company-staging.skore.ai/graphql' \
--header 'Content-Type: application/json' \
--header 'authorization: Bearer <JWT>' \
--data '
  { "variables": { "id": "114" }, "query": "query ($id: String!) { company: getCompany(id: $id) { id language default_user_role subscription { max_seats } }}" }
'

curl --request POST --url 'https://company-staging.skore.ai/graphql' \
--header 'Content-Type: application/json' \
--header 'authorization: Bearer <JWT>' \
--data '
  { "variables": null, "query": "query { company: getCompany(id: \"114\") { id language default_user_role subscription { max_seats } }}" }
'
```
