### PR TITLE
feat(security): add isAdmin decorator

### DIFF
--- a/packages/security/README.md
+++ b/packages/security/README.md
@@ -1,1 +1,50 @@
 ## @nest-firebase/security
+
+## Description
+
+This module provides protection to actions/queries through decorators.
+
+## Installation
+
+```bash
+$ npm install --save @nest-firebase/security
+```
+
+## Methods
+
+| Name           | Description                                                     | .env           |
+| -------------- | --------------------------------------------------------------- | -------------- |
+| @isUser()      | Check if token belongs to a valid user                          | USER_AUTH_URL  |
+| @isAdmin()     | Check if token belongs to a valid admin user                    | USER_AUTH_URL  |
+| @isClient()    | Use google-auth-library to verify the integrity of the ID token | OAUTH_AUDIENCE |
+| @CurrentUser() | Get a payload with token owner data.                            |                |
+
+## Usage
+
+Just annotate yout REST actions and Graphql queries/mutations methods with decorator.
+
+The client should send a Bearer authorization header e.g., `'Authorization: Bearer JWT_TOKEN'`.
+
+You can also use the `@CurrentUser` param annotation to get access to the current user.
+
+1. Add `USER_AUTH_URL` or `OAUTH_AUDIENCE` to **.env**
+
+```env
+USER_AUTH_URL='https://knowledge-staging.skore.io/workspace/v1/users/current'
+OAUTH_AUDIENCE='https://test.skore.io'
+```
+
+2. Import the decorator and have fun
+
+```typescript
+import { IsUser, CurrentUser } from '@nest-firebase/security'
+
+@Controller('users')
+export class UserController {
+  @IsUser()
+  @Get()
+  async hello(@CurrentUser() user: any): string {
+    return user.companyId
+  }
+}
+```

--- a/packages/security/src/decorator/index.ts
+++ b/packages/security/src/decorator/index.ts
@@ -1,3 +1,4 @@
 export * from './current-user.decorator'
 export * from './is-client.decorator'
 export * from './is-user.decorator'
+export * from './is-admin.decorator'

--- a/packages/security/src/decorator/is-admin.decorator.ts
+++ b/packages/security/src/decorator/is-admin.decorator.ts
@@ -1,0 +1,6 @@
+import { UseGuards } from '@nestjs/common'
+import { AdminGuard } from '../guard'
+
+export function IsAdmin() {
+  return UseGuards(AdminGuard)
+}

--- a/packages/security/src/guard/admin.guard.ts
+++ b/packages/security/src/guard/admin.guard.ts
@@ -12,15 +12,14 @@ export class AdminGuard extends Guard {
   }
 
   async authorizeToken(token: string) {
-    return this.httpService
+    const { data } = await this.httpService
       .get(this.configService.get('USER_AUTH_URL'), {
         headers: { Authorization: token },
       })
       .toPromise()
-      .then(({ data }) => {
-        if (data.role !== 'admin') throw new ForbiddenException()
 
-        return data
-      })
+    if (data.role !== 'admin') throw new ForbiddenException()
+
+    return data
   }
 }

--- a/packages/security/src/guard/admin.guard.ts
+++ b/packages/security/src/guard/admin.guard.ts
@@ -1,0 +1,26 @@
+import { ForbiddenException, HttpService, Injectable } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { Guard } from './guard'
+
+@Injectable()
+export class AdminGuard extends Guard {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly httpService: HttpService,
+  ) {
+    super()
+  }
+
+  async authorizeToken(token: string) {
+    return this.httpService
+      .get(this.configService.get('USER_AUTH_URL'), {
+        headers: { Authorization: token },
+      })
+      .toPromise()
+      .then(({ data }) => {
+        if (data.role !== 'admin') throw new ForbiddenException()
+
+        return data
+      })
+  }
+}

--- a/packages/security/src/guard/index.ts
+++ b/packages/security/src/guard/index.ts
@@ -1,2 +1,3 @@
+export * from './admin.guard'
 export * from './client.guard'
 export * from './user.guard'

--- a/packages/security/test/guard/admin.guard.test.ts
+++ b/packages/security/test/guard/admin.guard.test.ts
@@ -1,0 +1,82 @@
+import * as request from 'supertest'
+import { HttpService, HttpStatus } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import { suite, test } from '@testdeck/jest'
+import { TestModule } from './test.module'
+
+@suite('[Guard] Admin Guard')
+export class AdminGuardTest {
+  private server: any
+
+  async before() {
+    const module = await Test.createTestingModule({ imports: [TestModule] })
+      .overrideProvider(HttpService)
+      .useValue({
+        get: (_path: string, params: any) => ({
+          toPromise: () => {
+            if (params.headers.Authorization !== 'SHOULD_ASSERT_OK')
+              throw new Error('Invalid token')
+
+            return Promise.resolve({ data: { id: 1, role: 'admin' } })
+          },
+        }),
+      })
+      .compile()
+
+    const app = await module.createNestApplication().init()
+
+    this.server = app.getHttpServer()
+  }
+
+  @test()
+  'Given no token provided then return 403'() {
+    return request(this.server)
+      .get('/admin')
+      .expect(HttpStatus.FORBIDDEN)
+  }
+
+  @test()
+  'Given invalid token then return 403'() {
+    return request(this.server)
+      .get('/admin')
+      .auth('invalid', { type: 'bearer' })
+      .expect(HttpStatus.FORBIDDEN)
+  }
+
+  @test()
+  async 'Given expert token then return 403'() {
+    const module = await Test.createTestingModule({ imports: [TestModule] })
+      .overrideProvider(HttpService)
+      .useValue({
+        get: (_path: string, params: any) => ({
+          toPromise: () => (Promise.resolve({ data: { id: 1, role: 'expert' } })),
+        }),
+      })
+      .compile()
+
+    const app = await module.createNestApplication().init()
+
+    return request(app.getHttpServer())
+      .get('/admin')
+      .auth('SHOULD_ASSERT_OK', { type: 'bearer' })
+      .expect(HttpStatus.FORBIDDEN)
+  }
+
+  @test()
+  'Given token sent without bearer then return 403'() {
+    return request(this.server)
+      .get('/admin')
+      .set('Authorization', 'SHOULD_ASSERT_OK')
+      .expect(HttpStatus.FORBIDDEN)
+  }
+
+
+  @test()
+  async 'Given admin token then return 200'() {
+    const response = await request(this.server)
+      .get('/admin')
+      .auth('SHOULD_ASSERT_OK', { type: 'bearer' })
+      .expect(HttpStatus.OK)
+    expect(response.body.id).toBe(1)
+  }
+}

--- a/packages/security/test/guard/test.module.ts
+++ b/packages/security/test/guard/test.module.ts
@@ -13,6 +13,7 @@ import {
   CurrentUser,
   IsClient,
   IsUser,
+  IsAdmin,
   UserGuard,
 } from '../../src'
 
@@ -28,6 +29,12 @@ export class AuthedController {
   @IsUser()
   user(@CurrentUser() user: any) {
     return user
+  }
+
+  @Get('admin')
+  @IsAdmin()
+  admin(@CurrentUser() admin: any) {
+    return admin
   }
 }
 


### PR DESCRIPTION
![gif-or-image](https://media.giphy.com/media/21GCae4djDWtP5soiY/giphy-downsized.gif)

### What?

Add `isAdmin` decorator.

### Why?

To centralize the logic to verify that the user is an administrator.